### PR TITLE
fix(seedly/text): carry-forward responsive typography

### DIFF
--- a/.changeset/fix-responsive-typography-carry-forward.md
+++ b/.changeset/fix-responsive-typography-carry-forward.md
@@ -1,0 +1,6 @@
+---
+'@kalink-ui/seedly': patch
+---
+
+Text/Heading: fix responsive typography by carrying forward `variant` and `size` across breakpoints so larger viewports don't reapply base styles. Also updates Heading story to demonstrate responsive behavior.
+

--- a/packages/seedly/src/components/heading/heading.stories.tsx
+++ b/packages/seedly/src/components/heading/heading.stories.tsx
@@ -41,3 +41,10 @@ export const WithSubtitle: Story = {
     subtitle: <Heading.Subtitle spacing={2}>Lorem ipsum</Heading.Subtitle>,
   },
 };
+
+export const Responsive: Story = {
+  args: {
+    variant: { xs: 'headline', lg: 'display' },
+    size: { xs: 'small', lg: 'large' },
+  },
+};

--- a/packages/seedly/src/components/text/text.responsive.ts
+++ b/packages/seedly/src/components/text/text.responsive.ts
@@ -30,8 +30,10 @@ export function buildTypographyOverrides(opts: {
     defaultOrder,
   );
 
-  const baseVariant = varMap.xs ?? variant;
-  const baseSize = sizeMap.xs ?? size;
+  // Carry forward variant/size values across breakpoints so that
+  // a value set at md persists to lg/xl/... unless overridden again.
+  let currentVariant = varMap.xs ?? (variant as TypographyVariant | undefined);
+  let currentSize = sizeMap.xs ?? (size as TypographySize | undefined);
 
   const classes: string[] = [];
 
@@ -40,11 +42,16 @@ export function buildTypographyOverrides(opts: {
       continue;
     }
 
-    const v = varMap[bp] ?? baseVariant;
-    const s = sizeMap[bp] ?? baseSize;
+    if (varMap[bp] != null) {
+      currentVariant = varMap[bp];
+    }
 
-    if (v && s) {
-      const key = `${String(v)}.${String(s)}`;
+    if (sizeMap[bp] != null) {
+      currentSize = sizeMap[bp];
+    }
+
+    if (currentVariant && currentSize) {
+      const key = `${String(currentVariant)}.${String(currentSize)}`;
       const cls = (
         typographyAt as Record<
           Exclude<BreakpointWithBase, 'xs'>,

--- a/packages/seedly/src/components/text/text.stories.tsx
+++ b/packages/seedly/src/components/text/text.stories.tsx
@@ -55,3 +55,10 @@ export const Align: Story = {
     align: 'center',
   },
 };
+
+export const Responsive: Story = {
+  args: {
+    variant: { xs: 'body', lg: 'title' },
+    size: { xs: 'small', lg: 'large' },
+  },
+};


### PR DESCRIPTION
- Prevent base typography from overriding responsive sizes at larger breakpoints by carrying forward variant/size across breakpoints.
- Story: add responsive example for Heading (variant + size) to verify behavior.